### PR TITLE
Add fixes to workflow for multiple outputs in op

### DIFF
--- a/xicam/core/execution/workflow.py
+++ b/xicam/core/execution/workflow.py
@@ -465,6 +465,8 @@ class Graph(object):
 
         # for each operation
         for input_operation in self.operations:
+            if input_operation in self._disabled_operations:
+                continue
 
             # for each input of given operation
             for input_name in input_operation.input_names:
@@ -472,6 +474,8 @@ class Graph(object):
                 matchness = 0
                 # Parse backwards from the given operation, looking for matching outputs
                 for output_operation in reversed(self.operations[: self.operations.index(input_operation)]):
+                    if output_operation in self._disabled_operations:
+                        continue
                     # check each output
                     for output_name in output_operation.output_names:
                         # if matching name

--- a/xicam/core/execution/workflow.py
+++ b/xicam/core/execution/workflow.py
@@ -1,6 +1,6 @@
 from xicam.plugins import OperationPlugin
 from typing import Callable, List, Union, Tuple
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from xicam.core import msg, execution
 from xicam.core.threads import QThreadFuture, QThreadFutureIterator
 from weakref import ref
@@ -272,7 +272,7 @@ class Graph(object):
         dask_graph = {}
 
         for operation in self.operations:
-            links = {}
+            links = OrderedDict()
             dependent_ids = []
             for dep_operation, inbound_links in self._inbound_links[operation].items():
                 for (source_param, dest_param) in inbound_links:
@@ -546,10 +546,9 @@ class _OperationWrapper:
         node_args = {}
         # Only try to extract input args when we are not at a start node
         if len(args):
-            args = args[0]  # Pull the filled args out of the tuple
             # Map the source args names and values to the destination op's inputs
             for arg, (input_name, sender_input_name) in zip(args, self.named_args.items()):
-                node_args[input_name] = args[sender_input_name]
+                node_args[input_name] = arg[sender_input_name]
 
         result_keys = self.node.output_names
         result_values = self.node(**node_args)

--- a/xicam/core/execution/workflow.py
+++ b/xicam/core/execution/workflow.py
@@ -537,9 +537,18 @@ class _OperationWrapper:
     # args = [{'name':value}]
 
     def __call__(self, *args):
+        # Potential inputs:
+        # args is an empty tuple ()
+        # args is a single length tuple with one-element dict ({'x': 1},)
+        # args is a single length tuple with n-element dict ({'x': 1, 'y': 2},)
+        # TODO: is multiple length tuple possible here? ({'x': 1}, {'y': 2})
         node_args = {}
-        for arg, (input_name, sender_operation_name) in zip(args, self.named_args.items()):
-            node_args[input_name] = arg[sender_operation_name]
+        # Only try to extract input args when we are not at a start node
+        if len(args):
+            args = args[0]  # Pull the filled args out of the tuple
+            # Map the source args names and values to the destination op's inputs
+            for arg, (input_name, sender_input_name) in zip(args, self.named_args.items()):
+                node_args[input_name] = args[sender_input_name]
 
         result_keys = self.node.output_names
         result_values = self.node(**node_args)

--- a/xicam/core/execution/workflow.py
+++ b/xicam/core/execution/workflow.py
@@ -542,6 +542,7 @@ class _OperationWrapper:
         # args is a single length tuple with one-element dict ({'x': 1},)
         # args is a single length tuple with n-element dict ({'x': 1, 'y': 2},)
         # TODO: is multiple length tuple possible here? ({'x': 1}, {'y': 2})
+        print(f"Node name: {self.node.name}\n\tcall args: {args}\n\tnamed_args: {self.named_args}")
         node_args = {}
         # Only try to extract input args when we are not at a start node
         if len(args):

--- a/xicam/core/execution/workflow.py
+++ b/xicam/core/execution/workflow.py
@@ -277,7 +277,7 @@ class Graph(object):
             for dep_operation, inbound_links in self._inbound_links[operation].items():
                 for (source_param, dest_param) in inbound_links:
                     links[dest_param] = source_param
-                dependent_ids.append(dep_operation.id)
+                    dependent_ids.append(dep_operation.id)
 
             node = _OperationWrapper(operation, links)
             dask_graph[operation.id] = (node, *dependent_ids)

--- a/xicam/core/execution/workflow.py
+++ b/xicam/core/execution/workflow.py
@@ -546,7 +546,7 @@ class _OperationWrapper:
         # args is a single length tuple with one-element dict ({'x': 1},)
         # args is a single length tuple with n-element dict ({'x': 1, 'y': 2},)
         # TODO: is multiple length tuple possible here? ({'x': 1}, {'y': 2})
-        print(f"Node name: {self.node.name}\n\tcall args: {args}\n\tnamed_args: {self.named_args}")
+        # print(f"Node name: {self.node.name}\n\tcall args: {args}\n\tnamed_args: {self.named_args}")
         node_args = {}
         # Only try to extract input args when we are not at a start node
         if len(args):
@@ -559,7 +559,14 @@ class _OperationWrapper:
         if not isinstance(result_values, tuple):
             result_values = (result_values,)
 
-        return dict(zip(result_keys, result_values))
+        results_dict = dict(zip(result_keys, result_values))
+        data_dict = {**results_dict, **node_args}
+
+        if self.node.hints:
+            for hint in self.node.hints:
+                hint.set_data(data_dict)
+
+        return results_dict
 
     def __repr__(self):
         # return getattr(self.node, "name", self.node.__class__.__name__)

--- a/xicam/core/tests/test_workflow_.py
+++ b/xicam/core/tests/test_workflow_.py
@@ -690,7 +690,6 @@ class TestMultipleOutputsOneOp:
         w.add_operations(op)
         result = w.execute_synchronous(a1=1, a2=2)
         assert result == ({"my_func": 1},)
-        assert False  # TODO is above assertion expected behavior?
 
 
 class TestMultipleOutputsMultipleOps:

--- a/xicam/core/tests/workflow_fixtures.py
+++ b/xicam/core/tests/workflow_fixtures.py
@@ -51,6 +51,33 @@ def negative_op():
 
 
 @pytest.fixture()
+def a_op():
+    @operation
+    @output_names("n")
+    def a(n: int) -> int:
+        return n + 1
+    return a()
+
+
+@pytest.fixture()
+def b_op():
+    @operation
+    @output_names("n")
+    def b(n: int) -> int:
+        return n - 1
+    return b()
+
+
+@pytest.fixture()
+def c_op():
+    @operation
+    @output_names("n")
+    def c(n: int) -> int:
+        return n * n
+    return c()
+
+
+@pytest.fixture()
 def simple_workflow(square_op, sum_op):
     from xicam.core.execution.workflow import Workflow
 

--- a/xicam/core/tests/workflow_fixtures.py
+++ b/xicam/core/tests/workflow_fixtures.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 import pytest
 
 from xicam.core import execution
@@ -11,6 +12,15 @@ from pyqtgraph.parametertree import Parameter
 @pytest.fixture()
 def graph():
     return Graph()
+
+
+@pytest.fixture()
+def double_and_triple_op():
+    @operation
+    @output_names("double", "triple")
+    def double_and_triple(n: int) -> Tuple[int, int]:
+        return 2*n, 3*n
+    return double_and_triple()
 
 
 @pytest.fixture()

--- a/xicam/gui/widgets/ROI.py
+++ b/xicam/gui/widgets/ROI.py
@@ -10,16 +10,18 @@ from xicam.plugins import OperationPlugin
 from pyqtgraph.parametertree import Parameter, parameterTypes
 import pyqtgraph as pg
 
+from xicam.plugins.operationplugin import operation, output_names
+
 
 class ROIProcessingPlugin(OperationPlugin):
     name = 'ROI'
-    output_names = ('ROI', 'data')
+    output_names = ('roi', 'data')
+    input_names = ('data', 'image')
 
     def __init__(self, ROI: ROI):
         super(ROIProcessingPlugin, self).__init__()
         self.ROI = ROI
         self._param = None  # type: Parameter
-
         self.name = f"ROI #{self.ROI.index}"
 
     def _func(self, data, image):

--- a/xicam/plugins/hints.py
+++ b/xicam/plugins/hints.py
@@ -13,11 +13,12 @@ from xicam.gui.widgets.plotwidgetmixins import CurveLabels
 class Hint(object):
     canvas_cls = None
 
-    def __init__(self, **kwargs):
+    def __init__(self, group:str = None, **kwargs):
         self.parent = None
         self.checked = False
         self.enabled = True
         self._name = None
+        self.group = group
 
     def init_canvas(self, **kwargs):
         return self.canvas_cls()
@@ -45,11 +46,13 @@ class PlotHint(Hint):
                  yKey: str,
                  xLog: bool = False,
                  yLog: bool = False,
+                 group: str = None,
                  labels=None,
                  **kwargs):
-        super(PlotHint, self).__init__()
+        super(PlotHint, self).__init__(group)
         if kwargs.get("name"):
             self._name = kwargs["name"]
+        self.group = group or self._name
         self.x = self.y = []
         self.xKey = xKey
         self.yKey = yKey
@@ -167,16 +170,16 @@ class ImageHint(Hint):
     ref_count = count(0)
 
     def __init__(
-        self, imagekey, name="", invertY=False, xlabel: str = None, ylabel: str = None, transform=None, z: int = None, **kwargs
+        self, imagekey, name="", invertY=False, labels=None, transform=None, z: int = None, **kwargs
     ):
         self._name = name
         super(ImageHint, self).__init__()
+        self.group = self._name
         self.count = next(self.ref_count)
         self.image = None
         self.imagekey = imagekey
         self.invertY = invertY
-        self.xlabel = xlabel
-        self.ylabel = ylabel
+        self.labels = labels
         self.transform = transform
         if transform is None:
             transform = QTransform()
@@ -196,8 +199,8 @@ class ImageHint(Hint):
         self.image = data.get(self.imagekey, [])
 
     def init_canvas(self, **kwargs):
-        x = self.xlabel or f"{self.image_key}<sub>1</sub>"
-        y = self.ylabel or f"{self.image_key}<sub>2</sub>"
+        x = self.labels["left"] or f"{self.image_key}<sub>1</sub>"
+        y = self.labels["bottom"] or f"{self.image_key}<sub>2</sub>"
         self.canvas = self.canvas_cls(view=pg.PlotItem(labels=dict(left=y, bottom=x)))
         self.canvas.view.invertY(self.invertY)
         return self.canvas
@@ -206,6 +209,7 @@ class ImageHint(Hint):
     def name(self):
         if not self._name:
             self._name = "Image " + str(self.count)
+            self.group = self._name
         return self._name
 
     def visualize(self, canvas):

--- a/xicam/plugins/hints.py
+++ b/xicam/plugins/hints.py
@@ -52,6 +52,7 @@ class PlotHint(Hint):
         self.xLog = xLog
         self.yLog = yLog
         self.labels = labels
+        print(self._name, xLog, yLog)
 
     def init_canvas(self, addLegend=False, **kwargs):
         canvas = super(PlotHint, self).init_canvas(**kwargs)

--- a/xicam/plugins/hints.py
+++ b/xicam/plugins/hints.py
@@ -40,19 +40,37 @@ class Hint(object):
 class PlotHint(Hint):
     canvas_cls = CurveLabels
 
-    def __init__(self, x: np.ndarray, y: np.ndarray, xLog: bool = False, yLog: bool = False, labels=None, **kwargs):
+    def __init__(self,
+                 xKey: str,
+                 yKey: str,
+                 xLog: bool = False,
+                 yLog: bool = False,
+                 labels=None,
+                 **kwargs):
         super(PlotHint, self).__init__()
         if kwargs.get("name"):
             self._name = kwargs["name"]
-        self.x = x
-        self.y = y
+        self.x = self.y = []
+        self.xKey = xKey
+        self.yKey = yKey
         self.kwargs = kwargs
         self.item = None
         self.canvas = None
         self.xLog = xLog
         self.yLog = yLog
         self.labels = labels
-        print(self._name, xLog, yLog)
+
+    @property
+    def x_key(self):
+        return self.xKey
+
+    @property
+    def y_key(self):
+        return self.yKey
+
+    def set_data(self, data: dict):
+        self.x = data.get(self.x_key, [])
+        self.y = data.get(self.y_key, [])
 
     def init_canvas(self, addLegend=False, **kwargs):
         canvas = super(PlotHint, self).init_canvas(**kwargs)
@@ -73,7 +91,7 @@ class PlotHint(Hint):
 
     def visualize(self, canvas, color=None):
         plotItem = canvas.plotItem
-        plotItem.setLabels(**(self.labels or {}))
+        plotItem.setLabels(**(self.labels or {"bottom": self.x_key, "left": self.y_key}))
         plotItem.setLogMode(x=self.xLog, y=self.yLog)
         if self.kwargs.get("name"):
             self.item = canvas.plot(self.x, self.y, **self.kwargs)
@@ -149,12 +167,13 @@ class ImageHint(Hint):
     ref_count = count(0)
 
     def __init__(
-        self, image, name="", invertY=False, xlabel: str = None, ylabel: str = None, transform=None, z: int = None, **kwargs
+        self, imagekey, name="", invertY=False, xlabel: str = None, ylabel: str = None, transform=None, z: int = None, **kwargs
     ):
         self._name = name
         super(ImageHint, self).__init__()
         self.count = next(self.ref_count)
-        self.image = image
+        self.image = None
+        self.imagekey = imagekey
         self.invertY = invertY
         self.xlabel = xlabel
         self.ylabel = ylabel
@@ -169,8 +188,17 @@ class ImageHint(Hint):
         self.enabled = False
         self.canvas = None
 
+    @property
+    def image_key(self):
+        return self.imagekey
+
+    def set_data(self, data: dict):
+        self.image = data.get(self.imagekey, [])
+
     def init_canvas(self, **kwargs):
-        self.canvas = self.canvas_cls(view=pg.PlotItem(labels=dict(left=self.xlabel, bottom=self.ylabel)))
+        x = self.xlabel or f"{self.image_key}<sub>1</sub>"
+        y = self.ylabel or f"{self.image_key}<sub>2</sub>"
+        self.canvas = self.canvas_cls(view=pg.PlotItem(labels=dict(left=y, bottom=x)))
         self.canvas.view.invertY(self.invertY)
         return self.canvas
 

--- a/xicam/plugins/operationplugin.py
+++ b/xicam/plugins/operationplugin.py
@@ -9,7 +9,7 @@ from pyqtgraph.parametertree import Parameter
 
 from xicam.core import msg
 
-from .hints import PlotHint
+from .hints import PlotHint, ImageHint
 from .plugin import PluginType
 
 
@@ -669,6 +669,14 @@ def limits(arg_name, limit):
 
 
 # TODO: need an image_hint decorator? coplot_hint decorator?
+def image_hint(*args, **kwargs):
+    def decorator(func):
+        if not hasattr(func, 'hints'):
+            func.hints = []
+        func.hints.append(ImageHint(*args, **kwargs))
+        return func
+
+    return decorator
 
 # TODO Check that signature propagates up
 def plot_hint(*args, **kwargs):

--- a/xicam/plugins/operationplugin.py
+++ b/xicam/plugins/operationplugin.py
@@ -174,8 +174,8 @@ class OperationPlugin(PluginType):
     filled_values = _OperationDict()  # type: _OperationDict
     fixable = {}  # type: dict
     fixed = _OperationDict(opts_key="fixed") # type: _OperationDict
-    input_names = None  # type: Tuple[str]
-    output_names = None  # type: Tuple[str]
+    input_names = tuple()  # type: Tuple[str]
+    output_names = tuple()  # type: Tuple[str]
     limits = {}  # type: dict
     opts = {}  # type: dict
     output_shape = {}  # type: dict
@@ -196,11 +196,14 @@ class OperationPlugin(PluginType):
         self.fixable = self.fixable.copy()
         self.fixed = self.fixed.copy()
         self.fixed.operation = self  # Need to add the operation ref to our OperationDict
+        self.hints = self.hints.copy()
+        self.input_descriptions = self.input_descriptions.copy()
         self.limits = self.limits.copy()
         self.opts = self.opts.copy()
+        self.output_descriptions = self.output_descriptions.copy()
         self.output_shape = self.output_shape.copy()
         self.units = self.units.copy()
-        self.hints = self.hints.copy()
+        self.visible = self.visible.copy()
         self._parameter = None  # type: weakref.ref
 
     @classmethod
@@ -238,10 +241,10 @@ class OperationPlugin(PluginType):
                     invalid_msg += f"\"{arg}\" is not a valid input for \"{name}\". "
 
         # Warn if there are no output_names defined
-        if not len(cls.output_names):
+        if not len(cls.output_names) or cls.output_names[0] == cls._func.__name__:
             warning_msg = (f"No output_names have been specified for your operation {cls}; "
-                           f"you will not be able to connect your operation's output(s) to "
-                           f"any other operations.")
+                           f"using {cls._func.__name__} as default output name. "
+                           f"This may cause issues if your operation has multiple outputs.")
             msg.logMessage(warning_msg, level=msg.WARNING)
 
         # Define which "output" arg properties we want to check

--- a/xicam/plugins/operationplugin.py
+++ b/xicam/plugins/operationplugin.py
@@ -284,7 +284,11 @@ class OperationPlugin(PluginType):
         if not return_annotation or return_annotation is inspect.Signature.empty:
             return_annotation = tuple()
 
-        output_type_map = OrderedDict(zip(self.output_names, return_annotation.__args__))
+        # output_type_map = OrderedDict(zip(self.output_names, return_annotation.__args__))
+        if not type(return_annotation) is tuple:
+            return_annotation = (return_annotation,)
+
+        output_type_map = OrderedDict(zip(self.output_names, return_annotation))
         return output_type_map
 
     def __reduce__(self):

--- a/xicam/plugins/operationplugin.py
+++ b/xicam/plugins/operationplugin.py
@@ -189,6 +189,8 @@ class OperationPlugin(PluginType):
 
     def __init__(self, **filled_values):
         super(OperationPlugin, self).__init__()
+        self._parameter = None  # type: weakref.ref
+        self.opts = self.opts.copy()
         # Copy class dict information so that changes to instance don't propagate to class
         self.filled_values = self.filled_values.copy()
         self.filled_values.operation = self  # Need to add the operation ref to our OperationDict
@@ -204,7 +206,6 @@ class OperationPlugin(PluginType):
         self.output_shape = self.output_shape.copy()
         self.units = self.units.copy()
         self.visible = self.visible.copy()
-        self._parameter = None  # type: weakref.ref
 
     @classmethod
     def _validate(cls):

--- a/xicam/plugins/operationplugin.py
+++ b/xicam/plugins/operationplugin.py
@@ -201,6 +201,7 @@ class OperationPlugin(PluginType):
         self.hints = self.hints.copy()
         self.input_descriptions = self.input_descriptions.copy()
         self.limits = self.limits.copy()
+        self.name = self.name or getattr(self._func, "name", self._func.__name__)
         self.opts = self.opts.copy()
         self.output_descriptions = self.output_descriptions.copy()
         self.output_shape = self.output_shape.copy()

--- a/xicam/plugins/tests/test_OperationPlugin.py
+++ b/xicam/plugins/tests/test_OperationPlugin.py
@@ -135,6 +135,16 @@ class TestOutputNames:
         op = operation(my_sum)
         assert op.output_names == ("sum",)
 
+    def test_output_names_tuple(self):
+        @output_names("x", "y")
+        def my_solution(n):
+            return n, -1 * n
+
+        assert my_solution.output_names == ("x", "y")
+        # Test operation API
+        op = operation(my_solution)
+        assert op.output_names == ("x", "y")
+
     def test_output_names_none_provided(self, caplog):
         def my_op(a, b):
             return 42
@@ -497,9 +507,8 @@ def test_multiple_instances(square_op, sum_op):
     wf.add_operation(square)
     wf.add_operation(square2)
     wf.add_operation(my_sum)
-    wf.add_link(square, my_sum, "square", "a")
-    wf.add_link(square2, my_sum, "square", "b")
-
+    wf.add_link(square, my_sum, "square", "a")  # 3**3
+    wf.add_link(square2, my_sum, "square", "b") # 2**2
     assert wf.execute_synchronous(executor=executor) == [{"sum": 13}]
 
 


### PR DESCRIPTION
With operations that have multiple outputs (e.g. `return x, y`), the zipping in `_OperationWrapper.__call__` wouldn't correctly map all the outputs to the next operations inputs (it would only map the first value).

Also updated some tests.

Includes some other fixes.