### PR TITLE
Add TIFF and JPEG support to Xi-CAM

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,13 @@ setup(
     # pip to create the appropriate form of executable for the target platform.
     entry_points={
         "gui_scripts": ["xicam=xicam.run_xicam:main"],
-        "xicam.plugins.DataHandlerPlugin": ["npy = xicam.core.formats.NPYPlugin:NPYPlugin"],
+        "databroker.ingestors": [
+            "image/jpeg = xicam.core.ingestors.generic:ingest",
+            "image/tiff = xicam.core.ingestors.generic:ingest",
+        ],
+        "xicam.plugins.DataHandlerPlugin": [
+            "npy = xicam.core.formats.NPYPlugin:NPYPlugin",
+        ],
         "xicam.plugins.PluginType": [
             "CatalogPlugin = xicam.plugins.catalogplugin:CatalogPlugin",
             "ControllerPlugin = xicam.plugins.controllerplugin:ControllerPlugin",

--- a/xicam/core/ingestors/generic.py
+++ b/xicam/core/ingestors/generic.py
@@ -1,0 +1,80 @@
+"""Generic ingestion of raw images using the fabIO package.
+
+Current registered formats can be found under the 'databroker.ingestors' entry point
+in xicam's setup.py.
+"""
+import time
+
+import dask.array as da
+import event_model
+import fabio
+
+
+def _get_slice(image, frame):
+    return image.get_frame(frame).data
+
+
+def ingest(paths):
+    """Ingest a generic image file.
+
+    Can be used to load any formats that FabIO can read.
+
+    Parameters
+    ----------
+    paths: List
+        List of file paths to ingest. Note that only a single path is currently supported.
+    """
+    assert len(paths) == 1
+    path = paths[0]
+    image = fabio.open(path)  # type: fabio.fabioimage.FabioImage
+
+    # Create a BlueskyRun
+    run_bundle = event_model.compose_run()
+
+    # Create the start document
+    start_doc = run_bundle.start_doc
+    start_doc["sample_name"] = image.filename
+    yield "start", start_doc
+
+    # Create the descriptor document - defines the data keys
+    source = image.header.get("source", "Local")
+    frame_data_keys = {
+        "raw": {"source": source, "dtype": "number", "shape": (image.nframes, *image.shape)}
+    }
+    frame_stream_name = "primary"
+    frame_stream_bundle = run_bundle.compose_descriptor(
+        data_keys=frame_data_keys, name=frame_stream_name
+    )
+    yield "descriptor", frame_stream_bundle.descriptor_doc
+
+    # Create the event document - contains the data
+    # delayed_get_slice = dask.delayed(_get_slice)
+    # dask_data = da.stack(
+    #     [da.from_delayed(delayed_get_slice(image, frame), shape=image.shape, dtype=image.dtype)
+    #     for frame in range(image.nframes)]
+    # )
+    dask_data = da.stack([frame.data for frame in image.frames()])
+    timestamp = image.header.get("time", time.time())
+    yield "event", frame_stream_bundle.compose_event(
+        data={"raw": dask_data}, timestamps={"raw": timestamp}
+    )
+
+    # Create the stop document
+    yield "stop", run_bundle.compose_stop()
+
+
+if __name__ == "__main__":
+    from pathlib import Path
+    import numpy as np
+    import tempfile
+    import tifffile
+
+    # Write a small TIF file
+    dd, _, _ = np.mgrid[0:30, 0:40, 0:50]
+    dd = dd.astype("<u2")
+
+    tmp = tempfile.TemporaryDirectory()
+    fPath = Path(tmp.name) / Path("temp_tif.tif")
+    tifffile.imsave(fPath, dd, imagej=True, resolution=(0.2, 0.2), metadata={"unit": "um"})
+    docs = list(ingest([str(fPath)]))
+    print(docs)

--- a/xicam/core/tests/test_ingestors.py
+++ b/xicam/core/tests/test_ingestors.py
@@ -1,0 +1,59 @@
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import tifffile
+from PIL import Image
+
+from xicam.core.ingestors import generic
+
+
+class TestGeneric:
+
+    def test_tiff(self):
+        # Write a small TIFF file
+        test_data, _, _ = np.mgrid[0:30, 0:40, 0:50]
+        test_data = test_data.astype("<u2")
+
+        tmp = tempfile.TemporaryDirectory()
+        file_path = Path(tmp.name) / Path("temp_tif.tif")
+        tifffile.imsave(
+            file_path, test_data, imagej=True, resolution=(0.2, 0.2), metadata={"unit": "um"}
+        )
+
+        # TODO test metadata
+
+        # Make sure we generated a valid doc
+        docs = list(generic.ingest([str(file_path)]))
+        assert len(docs) == 4
+        expected_keys = ["start", "descriptor", "event", "stop"]
+        for i, doc in enumerate(docs):
+            assert doc[0] == expected_keys[i]
+
+        # Try to read the event data
+        dask_array = docs[2][1]["data"]["raw"]  # type: dask.array
+        event_data = dask_array.compute()
+        assert np.array_equal(event_data, test_data)
+
+
+    def test_jpeg(self):
+        # Create a test image
+        image = Image.new("L", (10, 20), color=100)
+        tmp = tempfile.TemporaryDirectory()
+        file_path = Path(tmp.name) / Path("temp_jpeg.jpeg")
+        image.save(file_path)
+
+        # Ingest
+        docs = list(generic.ingest([str(file_path)]))
+
+        # Check that the document is valid
+        assert len(docs) == 4
+        expected_keys = ["start", "descriptor", "event", "stop"]
+        for i, _ in enumerate(docs):
+            assert docs[i][0] == expected_keys[i]
+
+        # Try to read the event data
+        dask_array = docs[2][1]["data"]["raw"]  # type: dask.array
+        event_data = dask_array.compute()
+        # The ingestor does a dask_array.stack, so we need to squeeze off the extra dimension
+        assert np.array_equal(event_data.squeeze(), np.asarray(image))


### PR DESCRIPTION
This will add support for generic loading of TIFFs and JPEGs.

More FabIO formats can be registered easily by adding entrypoints, with the name being the mimetype to register.

- [x] move this to another repo, like `xicam.common_ingestors`
