### PR TITLE
Fix preview for remote catalogs

### DIFF
--- a/xicam/gui/bluesky/databroker_catalog_plugin.py
+++ b/xicam/gui/bluesky/databroker_catalog_plugin.py
@@ -3,7 +3,6 @@ Catalog Plugin for browsing pre-configured databroker catalogs
 """
 from xicam.plugins.catalogplugin import CatalogPlugin
 from xicam.gui.widgets.dataresourcebrowser import QListView
-from databroker.core import BlueskyRun
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QWidget, QVBoxLayout
 import logging
@@ -23,7 +22,7 @@ class SearchingCatalogController(QWidget):
 
     sigOpen = Signal(object)
     sigSelectedRun = Signal([list])
-    sigPreview = Signal(BlueskyRun)
+    sigPreview = Signal(object)
     catalog = None
 
     def __init__(self, root_catalog):


### PR DESCRIPTION
Fixes #12 

When you setup an intake-server as your source, you a run is note represented as a BlueskyRun, rather a RemoteBlueskyRun which is, surprisingly, not a BlueskyRun.