### PR TITLE
Update appdirs with appauthor. Fixes #19.

### DIFF
--- a/xicam/core/paths.py
+++ b/xicam/core/paths.py
@@ -3,9 +3,12 @@ import os
 import platform
 
 
-user_cache_dir = user_cache_dir(appname="xicam")
-site_config_dir = site_config_dir(appname="xicam")
-user_config_dir = user_config_dir(appname="xicam")
+APP_NAME = "xicam"
+APP_AUTHOR = "CAMERA"
+
+user_cache_dir = user_cache_dir(appname=APP_NAME, appauthor=APP_AUTHOR)
+site_config_dir = site_config_dir(appname=APP_NAME, appauthor=APP_AUTHOR)
+user_config_dir = user_config_dir(appname=APP_NAME, appauthor=APP_AUTHOR)
 user_dev_dir = os.path.expanduser("~/Xi-cam/plugins")
 op_sys = platform.system()
 if op_sys == "Darwin":  # User config dir incompatible with venv on darwin (space in path name conflicts)

--- a/xicam/gui/cammart/packagemanager.py
+++ b/xicam/gui/cammart/packagemanager.py
@@ -5,7 +5,6 @@ import os, sys
 import pkg_resources
 import requests
 import yaml
-from appdirs import user_config_dir, site_config_dir, user_cache_dir
 import platform
 import subprocess
 from xicam.core import msg
@@ -13,6 +12,7 @@ from importlib import reload
 import pip
 from pathlib import Path
 
+from xicam.core.paths import user_config_dir, site_config_dir, user_cache_dir
 from . import venvs
 
 
@@ -47,10 +47,10 @@ def pipmain(args):
 
 op_sys = platform.system()
 if op_sys == "Darwin":  # User config dir incompatible with venv on darwin (space in path name conflicts)
-    user_package_registry = Path(user_cache_dir(appname="xicam")) / "packages.yml"
+    user_package_registry = Path(user_cache_dir) / "packages.yml"
 else:
-    user_package_registry = Path(user_config_dir(appname="xicam")) / "packages.yml"
-site_package_registry = Path(site_config_dir(appname="xicam")) / "packages.yml"
+    user_package_registry = Path(user_config_dir) / "packages.yml"
+site_package_registry = Path(site_config_dir) / "packages.yml"
 
 
 def install(name: str):

--- a/xicam/gui/cammart/venvs.py
+++ b/xicam/gui/cammart/venvs.py
@@ -5,19 +5,20 @@ import sys
 import venv
 
 import pathlib
-from appdirs import user_config_dir, site_config_dir, user_cache_dir
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QLabel
 
+from xicam.core.paths import user_cache_dir, user_config_dir, site_config_dir
 from xicam.gui.static import path
 from xicam.plugins import SettingsPlugin
 
+
 op_sys = platform.system()
 if op_sys == "Darwin":  # User config dir incompatible with venv on darwin (space in path name conflicts)
-    user_venv_dir = os.path.join(user_cache_dir(appname="xicam"), "venvs")
+    user_venv_dir = os.path.join(user_cache_dir, "venvs")
 else:
-    user_venv_dir = os.path.join(user_config_dir(appname="xicam"), "venvs")
-site_venv_dir = os.path.join(site_config_dir(appname="xicam"), "venvs")
+    user_venv_dir = os.path.join(user_config_dir, "venvs")
+site_venv_dir = os.path.join(site_config_dir, "venvs")
 
 venvs = {}
 observers = []

--- a/xicam/plugins/__init__.py
+++ b/xicam/plugins/__init__.py
@@ -5,7 +5,6 @@ import itertools
 import warnings
 
 import entrypoints
-from appdirs import user_config_dir, site_config_dir, user_cache_dir
 
 from xicam.core import msg
 from xicam.core import threads
@@ -41,14 +40,6 @@ from contextlib import contextmanager
 from timeit import default_timer
 
 import time
-
-op_sys = platform.system()
-if op_sys == "Darwin":  # User config dir incompatible with venv on darwin (space in path name conflicts)
-    user_plugin_dir = os.path.join(user_cache_dir(appname="xicam"), "plugins")
-else:
-    user_plugin_dir = os.path.join(user_config_dir(appname="xicam"), "plugins")
-site_plugin_dir = os.path.join(site_config_dir(appname="xicam"), "plugins")
-
 
 
 @contextmanager


### PR DESCRIPTION
Removed redundant re-implementation of `user_config_dir`, `user_plugin_dir`, etc. that are already defined in `xicam.core.paths`.