### PR TITLE
Refactor of plugin manager load procedure to track and check load state

### DIFF
--- a/xicam/plugins/__init__.py
+++ b/xicam/plugins/__init__.py
@@ -1,14 +1,20 @@
 import sys
-import os
-import platform
+import time
 import itertools
 import warnings
+from dataclasses import dataclass, field
+from typing import Type
+from queue import LifoQueue
+from enum import Enum, auto
+from contextlib import contextmanager
+from timeit import default_timer
 
 import entrypoints
 
 from xicam.core import msg
 from xicam.core import threads
 from xicam.core.args import parse_args
+from bluesky_widgets.qt.threading import GeneratorWorker
 
 from .datahandlerplugin import DataHandlerPlugin
 from .catalogplugin import CatalogPlugin
@@ -19,6 +25,10 @@ from .dataresourceplugin import DataResourcePlugin
 from .controllerplugin import ControllerPlugin
 from .widgetplugin import QWidgetPlugin
 from .plugin import PluginType
+from .dataresourceplugin import DataResourcePlugin
+from .fittablemodelplugin import Fittable1DModelPlugin
+from .ezplugin import _EZPlugin, EZPlugin
+from .hints import PlotHint, Hint
 
 try:
     # try to find the venvs entrypoint
@@ -29,17 +39,6 @@ try:
         raise ImportError
 except ImportError:
     venvsobservers = None
-from .dataresourceplugin import DataResourcePlugin
-from .fittablemodelplugin import Fittable1DModelPlugin
-from .ezplugin import _EZPlugin, EZPlugin
-from .hints import PlotHint, Hint
-
-from queue import LifoQueue
-from enum import Enum, auto
-from contextlib import contextmanager
-from timeit import default_timer
-
-import time
 
 
 @contextmanager
@@ -63,19 +62,40 @@ class Filters(Enum):
     COMPLETE = auto()
 
 
+class Status(Enum):
+    LoadingQueue = auto()
+    Loading = auto()
+    InstantiateQueue = auto()
+    Instantiating = auto()
+    Success = auto()
+    FailedLoad = auto()
+    FailedInstantiate = auto()
+
+
+@dataclass
+class PluginTask:
+    type_name: str
+    name: str
+    entry_point: entrypoints.EntryPoint = field(compare=False)
+    plugin_class: Type = field(default=None, compare=False)
+    status: Status = field(default=Status.Loading, compare=False)
+
+
 class XicamPluginManager:
     def __init__(self, qt_is_safe=False):
 
         self.qt_is_safe = qt_is_safe
         self._blacklist = []
+        self._tasks = []
         self._load_queue = LifoQueue()
         self._instantiate_queue = LifoQueue()
-        self._entrypoints = {}
-        self._load_cache = {}
         self._observers = []
-        self.state = State.READY
         self.type_mapping = {}
         self.plugin_types = {}
+        self.instantiating = False
+
+        # A QRunnable-based background Worker
+        self.plugin_loader = GeneratorWorker(self._load_plugins)
 
         # Remember all modules loaded before any plugins are loaded; don't bother unloading these
         self._preloaded_modules = set(sys.modules.keys())
@@ -112,8 +132,6 @@ class XicamPluginManager:
 
         # Initialize types
         self.type_mapping = {type_name: {} for type_name in self.plugin_types.keys()}
-        self._entrypoints = {type_name: {} for type_name in self.plugin_types.keys()}
-        self._load_cache = {type_name: {} for type_name in self.plugin_types.keys()}
 
     def collect_plugins(self):
         """
@@ -121,7 +139,8 @@ class XicamPluginManager:
 
         """
         self._discover_plugins()
-        self._load_plugins()
+        if not self.plugin_loader.is_running:
+            self.plugin_loader.start()
 
     def collect_plugin(self, plugin_name, plugin_class, type_name, replace=False):
         """
@@ -130,9 +149,7 @@ class XicamPluginManager:
         """
         if replace:
             # Clear cache by name
-            self._entrypoints[type_name].pop(plugin_name, None)
             self.type_mapping[type_name].pop(plugin_name, None)
-            self._load_cache[type_name].pop(plugin_name, None)
         else:
             try:
                 assert plugin_name not in self.type_mapping[type_name]
@@ -140,22 +157,27 @@ class XicamPluginManager:
                 raise ValueError(f"A plugin named {plugin_name} has already been loaded. Supply `replace=True` to override.")
 
         # Start a special collection cycle
-        self.state = State.DISCOVERING
+
         live_entry_point = LiveEntryPoint(plugin_name, plugin_class)
-        self._load_queue.put((type_name, live_entry_point))
-        if self.state == State.DISCOVERING:
-            self.state = State.LOADING
-        self._load_plugins()
+        task = PluginTask(type_name, plugin_name, live_entry_point, plugin_class)
+        if task not in self._tasks:
+            self._load_queue.put(task)
+            self._tasks.append(task)
+        else:
+            msg.logMessage(f"A plugin of type {type_name} named {task.name} is already in the queue.",
+                           level=msg.WARNING)
+
+        if not self.plugin_loader.is_running:
+            self.plugin_loader.start()
 
     def _unload_plugins(self):
-        assert self.state == State.READY
+
+        assert not self._tasks
         self._load_queue = LifoQueue()
         self._instantiate_queue = LifoQueue()
 
         # Initialize types
         self.type_mapping = {type_name: {} for type_name in self.plugin_types.keys()}
-        self._entrypoints = {type_name: {} for type_name in self.plugin_types.keys()}
-        self._load_cache = {type_name: {} for type_name in self.plugin_types.keys()}
 
         reload_candidates = list(filter(lambda key: key.startswith("xicam."), sys.modules.keys()))
         for module_name in reload_candidates:
@@ -168,9 +190,9 @@ class XicamPluginManager:
         self.collect_plugins()
 
     def _discover_plugins(self):
-        self.state = State.DISCOVERING
         # for each plugin type
         for type_name in self.plugin_types.keys():
+            tasks = []
 
             # get all entrypoints matching that group
             group = entrypoints.get_group_named(f"xicam.plugins.{type_name}")
@@ -181,14 +203,18 @@ class XicamPluginManager:
 
             for name, entrypoint in group.items():
                 # If this entrypoint hasn't already been queued
-                if entrypoint not in self._entrypoints[type_name] and entrypoint.name not in self._blacklist:
+                task = PluginTask(type_name, name, entrypoint)
+                if task not in self._tasks and entrypoint.name not in self._blacklist:
                     # ... queue and cache it
-                    self._load_queue.put((type_name, entrypoint))
-                    self._entrypoints[type_name][name] = entrypoint
+                    tasks.append(task)
+                    self._load_queue.put(task)
+                else:
+                    msg.logMessage(f"A plugin of type {type_name} named {task.name} is already in the queue.", level=msg.WARNING)
 
-            msg.logMessage(f"Discovered {type_name} entrypoints:", *self._entrypoints[type_name].values(), sep="\n")
-        if self.state == State.DISCOVERING:
-            self.state = State.LOADING
+            if tasks:
+                msg.logMessage(f"Discovered {type_name} entrypoints:", *map(lambda task: task.entry_point, tasks), sep="\n")
+
+            self._tasks.extend(tasks)
 
     @staticmethod
     def _check_shadows(group, group_all):
@@ -204,65 +230,63 @@ class XicamPluginManager:
                         f"Loading entrypoint from {winner.module_name} and ignoring others."
                     )
 
-    @threads.method(
-        threadkey="entrypoint-loader", showBusy=False, cancelIfRunning=False
-    )  # progress state managed independently
     def _load_plugins(self):
-        started_instantiating = False
-
         # For every entrypoint in the load queue
         while not self._load_queue.empty():
-            type_name, entrypoint = self._load_queue.get()
+            load_task = self._load_queue.get()
 
             # load it
-            self._load_plugin(type_name, entrypoint)
+            self._load_plugin(load_task)
 
-            if not started_instantiating:  # If this is the first load
+            if not self.instantiating:  # If this is the first load
                 # Start an event chain to pull from the queue
                 threads.invoke_as_event(self._instantiate_plugin)
-                started_instantiating = True
+                self.instantiating = True
 
             # mark it as completed
             self._load_queue.task_done()
+            yield
 
-        # Finished loading, progress
-        if self.state == State.LOADING:
-            self.state = State.INSTANTIATING
+    def _load_plugin(self, load_task:PluginTask):
+        entrypoint = load_task.entry_point
 
-    def _load_plugin(self, type_name, entrypoint: entrypoints.EntryPoint):
         # if the entrypoint was already loaded into cache and queued, do nothing
-        if self._load_cache[type_name].get(entrypoint.name, None):
+        if load_task.plugin_class is not None:
             return
+        else:
+            load_task.status = Status.Loading
 
         try:
             # Load the entrypoint (unless already cached), cache it, and put it on the instantiate queue
             msg.logMessage(f"Loading entrypoint {entrypoint.name} from module: {entrypoint.module_name}")
             with load_timer() as elapsed:
-                plugin_class = self._load_cache[type_name][entrypoint.name] = (
-                    self._load_cache[type_name].get(entrypoint.name, None) or entrypoint.load()
-                )
+                load_task.plugin_class = entrypoint.load()
         except (Exception, SystemError) as ex:
             msg.logMessage(f"Unable to load {entrypoint.name} plugin from module: {entrypoint.module_name}", msg.ERROR)
             msg.logError(ex)
             msg.notifyMessage(
                 repr(ex), title=f'An error occurred while starting the "{entrypoint.name}" plugin.', level=msg.CRITICAL
             )
+            load_task.status = Status.FailedLoad
 
         else:
             msg.logMessage(f"{int(elapsed() * 1000)} ms elapsed while loading {entrypoint.name}", level=msg.INFO)
-            self._instantiate_queue.put((type_name, entrypoint, plugin_class))
+            self._instantiate_queue.put(load_task)
+            load_task.status = Status.InstantiateQueue
 
     def _instantiate_plugin(self):
         if not self._instantiate_queue.empty():
-            type_name, entrypoint, plugin_class = self._instantiate_queue.get()
+            instantiate_task = self._instantiate_queue.get()
+            entrypoint = instantiate_task.entry_point
+            type_name = instantiate_task.type_name
+            plugin_class = instantiate_task.plugin_class
 
             # if this plugin was already instantiated earlier, skip it; mark done
             if self.type_mapping[type_name].get(entrypoint.name, None) is None:
+                instantiate_task.status = Status.Instantiating
 
                 # inject the entrypoint name into the class
                 plugin_class._name = entrypoint.name
-
-                success = False
 
                 # ... and instantiate it (as long as its supposed to be singleton)
 
@@ -277,7 +301,6 @@ class XicamPluginManager:
                         )
                     else:
                         self.type_mapping[type_name][entrypoint.name] = plugin_class
-                    success = True
 
                 except (Exception, SystemError) as ex:
                     msg.logMessage(
@@ -285,23 +308,27 @@ class XicamPluginManager:
                     )
                     msg.logError(ex)
                     msg.notifyMessage(repr(ex), title=f'An error occurred while starting the "{entrypoint.name}" plugin.')
+                    instantiate_task.status = Status.FailedInstantiate
 
-                if success:
+                else:
                     msg.logMessage(f"Successfully collected {entrypoint.name} plugin.", level=msg.INFO)
-                    msg.showProgress(self._progress_count(), maxval=self._entrypoint_count())
                     self._notify(Filters.UPDATE)
+
+                msg.showProgress(self._progress_count(), maxval=self._task_count())
 
             # mark it as completed
             self._instantiate_queue.task_done()
+            instantiate_task.status = Status.Success
 
         # If this was the last plugin
-        if self._load_queue.empty() and self._instantiate_queue.empty() and self.state in [State.INSTANTIATING, State.READY]:
-            self.state = State.READY
+        if self._load_queue.empty() and self._instantiate_queue.empty():
             msg.logMessage("Plugin collection completed!")
             msg.hideProgress()
             self._notify(Filters.COMPLETE)
+            self.instantiating = False
+            self._tasks.clear()
 
-        if not self.state == State.READY:  # if we haven't reached the last task, but there's nothing queued
+        else:  # if we haven't reached the last task, but there's nothing queued
             threads.invoke_as_event(self._instantiate_plugin)  # return to the event loop, but come back soon
 
     def _get_plugin_by_name(self, name, type_name):
@@ -355,35 +382,45 @@ class XicamPluginManager:
         if return_plugin:
             return return_plugin
 
-        # If still actively collecting plugins
-        if self.state != State.READY:
-            # find the matching entrypoint
-            entrypoint, type_name = self._get_entrypoint_by_name(name, type_name)
+        # Find the matching plugin from the queue
+        match_task = next(filter(lambda task: task.name==name and task.type_name == type_name, self._tasks), None)
 
-            if not entrypoint:
-                raise NameError(
-                    f"The plugin named {name} of type {type_name} could not be discovered. "
-                    f"Check your installation integrity."
-                )
+        # If the matched task is already failed
+        if match_task and match_task.status in [Status.FailedLoad, Status.FailedInstantiate]:
+            raise NameError(f"The plugin named {name} of type {type_name} has already failed to load.")
 
-            # Load it immediately; it will move to top of instantiate queue as well
-            msg.logMessage(f"Immediately loading {entrypoint.name}.", level=msg.INFO)
-            self._load_plugin(type_name, entrypoint)
+        # Otherwise, prioritize it
+        elif match_task:
+            self._load_plugin(match_task)
 
-            # Add another instantiate event to the Qt event queue, so that it triggers in the next event loop
-            threads.invoke_as_event(self._instantiate_plugin)
+            if not self.instantiating:
+                threads.invoke_as_event(self._instantiate_plugin)
+                self.instantiating = True
 
-            # wait for it to load
-            with load_timer() as elapsed:
-                while not return_plugin:
-                    return_plugin = self._get_plugin_by_name(name, type_name)
-                    if threads.is_main_thread():
-                        from qtpy.QtWidgets import QApplication  # Required as late import to avoid loading Qt things too soon
-                        QApplication.processEvents()
-                    else:
-                        time.sleep(0.01)
-                    if elapsed() > timeout:
-                        raise TimeoutError(f"Plugin named {name} waited too long to instantiate and timed out")
+
+        # Or, if there was no match
+        else:
+            raise NameError(
+                f"The plugin named {name} of type {type_name} could not be discovered. "
+                f"Check your installation integrity."
+            )
+
+        # wait for it to load
+        with load_timer() as elapsed:
+            while match_task.Status not in [Status.Success, Status.FailedInstantiate, Status.FailedLoad]:
+                if threads.is_main_thread():
+                    from qtpy.QtWidgets import QApplication  # Required as late import to avoid loading Qt things too soon
+                    QApplication.processEvents()
+                else:
+                    time.sleep(0.01)
+                if elapsed() > timeout:
+                    raise TimeoutError(f"Plugin named {name} waited too long to instantiate and timed out")
+
+        if match_task.Status in [Status.FailedInstantiate, Status.FailedLoad]:
+            raise NameError(f"The plugin named {name} of type {type_name} failed to load while we were waiting for it.")
+
+        elif match_task.Status == Status.Success:
+            return_plugin = self._get_plugin_by_name(name, type_name)
 
         return return_plugin
 
@@ -407,11 +444,11 @@ class XicamPluginManager:
     def venvChanged(self):
         self.collect_plugins()
 
-    def _entrypoint_count(self):
-        return sum(map(len, self._entrypoints.values()))
+    def _task_count(self):
+        return len(self._tasks)
 
     def _progress_count(self):
-        return sum(map(len, self.type_mapping.values()))
+        return len(list(filter(lambda task: task.status in [Status.Success, Status.FailedInstantiate, Status.FailedLoad], self._tasks)))
 
     def getPluginsOfCategory(self, type_name):
         raise NotImplementedError("This method has been renamed to follow snake_case")

--- a/xicam/plugins/__init__.py
+++ b/xicam/plugins/__init__.py
@@ -407,7 +407,7 @@ class XicamPluginManager:
 
         # wait for it to load
         with load_timer() as elapsed:
-            while match_task.Status not in [Status.Success, Status.FailedInstantiate, Status.FailedLoad]:
+            while match_task.status not in [Status.Success, Status.FailedInstantiate, Status.FailedLoad]:
                 if threads.is_main_thread():
                     from qtpy.QtWidgets import QApplication  # Required as late import to avoid loading Qt things too soon
                     QApplication.processEvents()
@@ -416,10 +416,10 @@ class XicamPluginManager:
                 if elapsed() > timeout:
                     raise TimeoutError(f"Plugin named {name} waited too long to instantiate and timed out")
 
-        if match_task.Status in [Status.FailedInstantiate, Status.FailedLoad]:
+        if match_task.status in [Status.FailedInstantiate, Status.FailedLoad]:
             raise NameError(f"The plugin named {name} of type {type_name} failed to load while we were waiting for it.")
 
-        elif match_task.Status == Status.Success:
+        elif match_task.status == Status.Success:
             return_plugin = self._get_plugin_by_name(name, type_name)
 
         return return_plugin

--- a/xicam/plugins/__init__.py
+++ b/xicam/plugins/__init__.py
@@ -262,7 +262,7 @@ class XicamPluginManager:
             with load_timer() as elapsed:
                 load_task.plugin_class = entrypoint.load()
         except (Exception, SystemError) as ex:
-            msg.logMessage(f"Unable to load {entrypoint.name} plugin from module: {entrypoint.module_name}", msg.ERROR)
+            msg.logMessage(f"Unable to load {entrypoint.name} plugin from module: {entrypoint.module_name}", level=msg.ERROR)
             msg.logError(ex)
             msg.notifyMessage(
                 repr(ex), title=f'An error occurred while starting the "{entrypoint.name}" plugin.', level=msg.CRITICAL

--- a/xicam/plugins/__init__.py
+++ b/xicam/plugins/__init__.py
@@ -274,9 +274,14 @@ class XicamPluginManager:
             self._instantiate_queue.put(load_task)
             load_task.status = Status.InstantiateQueue
 
-    def _instantiate_plugin(self):
-        if not self._instantiate_queue.empty():
-            instantiate_task = self._instantiate_queue.get()
+    def _instantiate_plugin(self, instantiate_task: PluginTask=None):
+        """
+        Instantiate a single plugin by request or from the queue. This is typically invoked by an event, and will re-post
+        an event to the event queue to repeat until the task queue is emptied.
+        """
+
+        if instantiate_task or not self._instantiate_queue.empty():
+            instantiate_task = instantiate_task or self._instantiate_queue.get()
             entrypoint = instantiate_task.entry_point
             type_name = instantiate_task.type_name
             plugin_class = instantiate_task.plugin_class


### PR DESCRIPTION
These changes provide the following advantages:
- The manager won't wait for a plugin to load if it had already failed or fails while waiting
- The manager won't re-queue loads when the venvs plugin loads; it checks equality based on type+name
- The manager won't repeatedly try to load a plugin has already failed during that collection in cases of dependent plugins
- Plugins won't time out due to cumulative costs associated with these extra waits
- Actually, the timeouts are now probably unnecessary, and might be deprecated later on

:clap: :smile_cat: