### PR TITLE
Add ingestors and sniffers as external plugin types managed by Xi-cam

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,8 @@ setup(
             'OperationPlugin = xicam.plugins.operationplugin:OperationPlugin',
             "SettingsPlugin = xicam.plugins.settingsplugin:SettingsPlugin",
             "QWidgetPlugin = xicam.plugins.widgetplugin:QWidgetPlugin",
+            "ingestors = xicam.plugins.ingestorplugin:IngestorPlugin",
+            "sniffers = xicam.plugins.snifferplugin:SnifferPlugin"
         ],
         "xicam.plugins.SettingsPlugin": [
             "logging = xicam.gui.settings.logging:LoggingSettingsPlugin",

--- a/xicam/core/data/__init__.py
+++ b/xicam/core/data/__init__.py
@@ -10,9 +10,6 @@ from warnings import warn
 import mimetypes
 import warnings
 
-import entrypoints
-
-
 def detect_mimetypes(filename: str) -> List[str]:
     """
     Take in a filename; return a mimetype string like 'image/tiff'.
@@ -26,15 +23,13 @@ def detect_mimetypes(filename: str) -> List[str]:
         # future if we discover reason to. Therefore, sniffers should not
         # assume that they will receive this exact number of bytes.
         first_bytes = file.read(64)
-    for ep in entrypoints.get_group_all("databroker.sniffers"):
-        try:
-            content_sniffer = ep.load()  # TODO: only load sniffers once
-        except Exception as ex:
-            msg.logError(ex)
-        else:
-            matched_mimetype = content_sniffer(filename, first_bytes)
-            if matched_mimetype:
-                matched_mimetypes.append(matched_mimetype)
+
+    from xicam.plugins import manager as plugin_manager
+
+    for sniffer in plugin_manager.get_plugins_of_type("sniffers"):
+        matched_mimetype = sniffer(filename, first_bytes)
+        if matched_mimetype:
+            matched_mimetypes.append(matched_mimetype)
 
     # Guessing the mimetype from the mimemtype db is quick, lets do it always
     matched_mimetype = mimetypes.guess_type(filename)[0]
@@ -53,14 +48,12 @@ def applicable_ingestors(filename, mimetype):
     """
     # Find ingestor(s) for this mimetype.
     ingestors = []
-    for ep in entrypoints.get_group_all("databroker.ingestors"):
-        if ep.name == mimetype:
-            try:
-                ingestor = ep.load()
-            except Exception as ex:
-                msg.logError(ex)
-            else:
-                ingestors.append(ingestor)
+
+    from xicam.plugins import manager as plugin_manager
+
+    for ingestor in plugin_manager.get_plugins_of_type("ingestors"):
+        if ingestor._name == mimetype:
+            ingestors.append(ingestor)
 
     return ingestors
 

--- a/xicam/plugins/__init__.py
+++ b/xicam/plugins/__init__.py
@@ -10,7 +10,6 @@ from xicam.core import msg
 from xicam.core import threads
 from xicam.core.args import parse_args
 
-from .datahandlerplugin import DataHandlerPlugin
 from .catalogplugin import CatalogPlugin
 from .guiplugin import GUIPlugin, GUILayout
 from .operationplugin import OperationPlugin
@@ -170,11 +169,11 @@ class XicamPluginManager:
     def _discover_plugins(self):
         self.state = State.DISCOVERING
         # for each plugin type
-        for type_name in self.plugin_types.keys():
+        for type_name, plugin_type in self.plugin_types.items():
 
             # get all entrypoints matching that group
-            group = entrypoints.get_group_named(f"xicam.plugins.{type_name}")
-            group_all = entrypoints.get_group_all(f"xicam.plugins.{type_name}")
+            group = entrypoints.get_group_named(f"{getattr(plugin_type,'entrypoint_prefix', 'xicam.plugins.')}{type_name}")
+            group_all = entrypoints.get_group_all(f"{getattr(plugin_type,'entrypoint_prefix', 'xicam.plugins.')}{type_name}")
 
             # check for duplicate names
             self._check_shadows(group, group_all)

--- a/xicam/plugins/ingestorplugin.py
+++ b/xicam/plugins/ingestorplugin.py
@@ -14,3 +14,4 @@ class IngestorPlugin():
     """
 
     entrypoint_prefix = 'databroker.'
+    needs_qt = False

--- a/xicam/plugins/ingestorplugin.py
+++ b/xicam/plugins/ingestorplugin.py
@@ -1,0 +1,16 @@
+"""
+Nothing useful here!
+Why?
+Because with the PluginType Plugin, we need to register the IngestorPlugin as an entrypoint for the manager to
+collect them. In this case, the only meaningful part is the name of the entrypoint, not what it points to. Of course,
+it has to point to something, so...
+"""
+from .plugin import PluginType
+
+
+class IngestorPlugin():
+    """
+    This is just to direct Xi-cam for how to load these plugins; its not intended to be instantiated or subclassed.
+    """
+
+    entrypoint_prefix = 'databroker.'

--- a/xicam/plugins/plugin.py
+++ b/xicam/plugins/plugin.py
@@ -1,6 +1,7 @@
 class PluginType:
     is_singleton = False
     entrypoint_prefix = 'xicam.plugins.'
+    needs_qt = True
 
     _name = None
 

--- a/xicam/plugins/plugin.py
+++ b/xicam/plugins/plugin.py
@@ -1,5 +1,6 @@
 class PluginType:
     is_singleton = False
+    entrypoint_prefix = 'xicam.plugins.'
 
     _name = None
 

--- a/xicam/plugins/snifferplugin.py
+++ b/xicam/plugins/snifferplugin.py
@@ -1,0 +1,16 @@
+"""
+Nothing useful here!
+Why?
+Because with the PluginType Plugin, we need to register the SnifferPlugin as an entrypoint for the manager to
+collect them. In this case, the only meaningful part is the name of the entrypoint, not what it points to. Of course,
+it has to point to something, so...
+"""
+from .plugin import PluginType
+
+
+class SnifferPlugin():
+    """
+    This is just to direct Xi-cam for how to load these plugins; its not intended to be instantiated or subclassed.
+    """
+
+    entrypoint_prefix = 'databroker.'

--- a/xicam/plugins/snifferplugin.py
+++ b/xicam/plugins/snifferplugin.py
@@ -14,3 +14,4 @@ class SnifferPlugin():
     """
 
     entrypoint_prefix = 'databroker.'
+    needs_qt = False


### PR DESCRIPTION
Ingestors and sniffers are now discovered through the xi-cam plugin manager. This could enable us to live-load these plugins, which is otherwise impractical through entrypoints alone. I plan to use this initially for testing, but it could later be used for live-development.

As a bonus, since the Xi-cam plugin manager aggressively loads the entrypoints it discovers, we won't have unexpected weirdness when trying to register mimetypes in the same module as an ingestor (otherwise that module would have to be explicitly imported elsewhere, @dylanmcreynolds ).