### PR TITLE
Add assign_signature decorator, with test

### DIFF
--- a/xicam/plugins/operationplugin.py
+++ b/xicam/plugins/operationplugin.py
@@ -1,6 +1,7 @@
 """TODO Module docstring"""
 import inspect
 import weakref
+import functools
 from typing import Collection, Tuple, Type, Union, List, Callable, Sequence
 from collections import OrderedDict
 from collections.abc import MutableMapping
@@ -927,3 +928,35 @@ def categories(*categories: Tuple[Union[tuple, str]]):
         return func
 
     return decorator
+
+
+def apply_signature(func: Callable):
+    """
+    Decorator to apply the signature of another function to this operation.
+
+    This is intended to be used in cases where you'd want to preserve the original function without duplicating the
+    signature in a wrapper function. This eliminates the need to have to update the wrapper when the original function
+    is edited
+
+    Parameters
+    ----------
+    func : Callable
+        A sequence of categories. Each item is a tuple or str. If an item is a tuple, each item in the tuple is considered
+        as an additional depth in the menu structure.
+
+    Example
+    --------
+
+    >>> def my_func(a:int=1, b:bool=True):
+    >>>     return True
+    >>>
+    >>> @operation
+    >>> @apply_signature(my_func)
+    >>> def wrapper_func(*args, **kwargs):
+    >>>     return my_func(*args, **kwargs)
+
+    The signature of the `wrapper_func` will then be `<Signature (a: int = 1, b: bool = False)>`, and Xi-cam
+    will use that information as it inspects this operation.
+    """
+
+    return functools.wraps(func)

--- a/xicam/plugins/tests/test_OperationPlugin.py
+++ b/xicam/plugins/tests/test_OperationPlugin.py
@@ -1,4 +1,5 @@
 import pytest
+import inspect
 
 import numpy as np
 
@@ -18,6 +19,7 @@ from xicam.plugins.operationplugin import (
     visible,
     ValidationError,
     operation,
+    apply_signature
 )
 
 
@@ -510,6 +512,19 @@ def test_multiple_instances(square_op, sum_op):
     wf.add_link(square, my_sum, "square", "a")  # 3**3
     wf.add_link(square2, my_sum, "square", "b") # 2**2
     assert wf.execute_synchronous(executor=executor) == [{"sum": 13}]
+
+
+def test_quick_wrap():
+    def some_external_function(a:int=1, b:bool=False):
+        return 2, True
+
+    @operation
+    @apply_signature(some_external_function)
+    def wrapped_external_function(*args, **kwargs):
+        return some_external_function(*args, **kwargs)
+
+    assert 'a' in inspect.signature(wrapped_external_function._func).parameters
+    assert 'b' in inspect.signature(wrapped_external_function._func).parameters
 
 
 #


### PR DESCRIPTION
This new operation decorator allows function wrapping while preserving signature (its really just functools.wraps 🤫).

@JulReinhardt Please test this with the operations you're writing for David.