### PR TITLE
Fix notify message to show notification

### DIFF
--- a/xicam/core/msg/__init__.py
+++ b/xicam/core/msg/__init__.py
@@ -105,15 +105,22 @@ stream_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)
 
 trayicon = None
-if "qtpy" in sys.modules:
-    from qtpy.QtWidgets import QApplication
 
-    if QApplication.instance():
-        from qtpy.QtWidgets import QSystemTrayIcon
-        from qtpy.QtGui import QIcon, QPixmap
-        from xicam.gui.static import path
 
-        trayicon = QSystemTrayIcon(QIcon(QPixmap(str(path("icons/cpu.png")))))  # TODO: better icon
+# FIXME: why isn't the application instance found during xi-cam startup?
+#   - this function is added to allow notifyMessage to reattempt creation of the system tray icon
+def _create_system_tray_icon():
+    if "qtpy" in sys.modules:
+        from qtpy.QtWidgets import QApplication
+
+        if QApplication.instance():
+            from qtpy.QtWidgets import QSystemTrayIcon
+            from qtpy.QtGui import QIcon, QPixmap
+            from xicam.gui.static import path
+
+            global trayicon
+            trayicon = QSystemTrayIcon(QIcon(QPixmap(str(path("icons/cpu.png")))))  # TODO: better icon
+
 
 _thread_count = 0
 
@@ -195,6 +202,10 @@ def notifyMessage(*args, timeout=8000, title="", level: int = INFO):
 
     """
     global trayicon
+    # FIXME: why do we need to recreate the trayicon when it was working before?
+    #     (see _create_system_tray_icon for notes)
+    if trayicon is None:
+        _create_system_tray_icon()
     if trayicon:
         icon = None
         if level in [INFO, DEBUG]:


### PR DESCRIPTION
Not sure which changes to xi-cam have caused `notifyMessage` to not work properly.

When it is called, the global system tray icon `trayicon` is None (should **not** be None unless platform doesn't support it -- I'm running Ubuntu which does support the global system tray icons).

Is this functionality change related to any modifications to the loading of xi-cam or it's splash screen?

@ronpandolfi  I'm looking for feedback if notifyMessage is already showing notifications on your system, and if it isn't working, any insights you may have into why this is happening?

### PR Changes

I've added a one-time recreation of the tray icon in `notifyMessage` if it is None. This works (suggesting that it should not be None in the first place).