### PR TITLE
Add interactive help widget for EnsembleGUIPlugin and some help documentation

### DIFF
--- a/xicam/gui/plugins/ensembleguiplugin.py
+++ b/xicam/gui/plugins/ensembleguiplugin.py
@@ -79,9 +79,7 @@ class HelpTextDisplay(QTextEdit):
 
         self.setContextMenuPolicy(Qt.NoContextMenu)
         self.setReadOnly(True)
-        self.setPlaceholderText("(No help available)\n\n"
-                                "For more detailed help, click on \"Help\", "
-                                "then \"Xi-CAM Help\" at the top.")
+        self.setPlaceholderText("(No help available for the widget at your current mouse location.)")
 
 class HelpWidget(QGroupBox):
     """Widget that displays interactive help text.

--- a/xicam/gui/plugins/ensembleguiplugin.py
+++ b/xicam/gui/plugins/ensembleguiplugin.py
@@ -73,6 +73,16 @@ class EnsembleGUIPlugin(GUIPlugin):
         self.ensemble_model.append_to_ensemble(catalog, None, self._projectors)
 
 
+class HelpTextDisplay(QTextEdit):
+    def __init__(self, text: str = "", parent=None):
+        super(HelpTextDisplay, self).__init__(text, parent)
+
+        self.setContextMenuPolicy(Qt.NoContextMenu)
+        self.setReadOnly(True)
+        self.setPlaceholderText("(No help available)\n\n"
+                                "For more detailed help, click on \"Help\", "
+                                "then \"Xi-CAM Help\" at the top.")
+
 class HelpWidget(QGroupBox):
     """Widget that displays interactive help text.
 
@@ -87,11 +97,7 @@ class HelpWidget(QGroupBox):
 
         self._install_event_filter()
 
-        self._help_display = QTextEdit()
-        self._help_display.setContextMenuPolicy(Qt.NoContextMenu)
-        self._help_display.setReadOnly(True)
-        self._help_display.setPlaceholderText("(No help available)")
-
+        self._help_display = HelpTextDisplay()
         layout = QVBoxLayout()
         layout.addWidget(self._help_display)
         self.setLayout(layout)

--- a/xicam/gui/plugins/ensembleguiplugin.py
+++ b/xicam/gui/plugins/ensembleguiplugin.py
@@ -1,23 +1,39 @@
-from databroker.core import BlueskyRun
+import weakref
 
-from xicam.core.workspace import Ensemble
+from qtpy.QtWidgets import QApplication, QWidget, QTextEdit, QGroupBox, QVBoxLayout
+from qtpy.QtCore import Qt, QEvent, QObject
+from databroker.core import BlueskyRun
+from xicam.core.execution import Workflow
+
 from xicam.gui.actions import Action
 from xicam.gui.models import EnsembleModel, IntentsModel
+from xicam.gui.widgets.linearworkfloweditor import WorkflowEditor
 from xicam.gui.widgets.views import DataSelectorView, StackedCanvasView
-from xicam.plugins import GUIPlugin
+from xicam.plugins import GUIPlugin, GUILayout
 
 
 class EnsembleGUIPlugin(GUIPlugin):
     """GUI plugin that uses the Xi-CAM 'Ensemble' architecture for data organization.
 
-    Includes an EnsembleModel, DataSelectorView, IntentsModel, and CanvasView.
-
-    Ensemble architecture is defined primarily by an EnsembleModel class.
-    This stores data in a Qt-based tree-like model, where each ensemble
-    encapsulates one or more catalogs, each of which may contain Intents
-    for how to visualize the data.
-
+    Attributes
+    ----------
+    canvases_view : StackedCanvasView
+        Canvas view attached to the `intents_model`, visualizes data.
+    ensemble_model : EnsembleModel
+        Model that stores Ensembles.
+    ensemble_view : DataSelectorView
+        View attached to `ensemble_model` that controls visualizing data.
+    intents_model : IntentsModel
+        Model that stores visualizable data in the `ensemble_model` (i.e. Intents).
+    gui_layout_template : dict
+        Dict that includes `canvases_view`, `ensemble_view`, `workflow_editor`, and `xi_help`.
+        Convenience as a template layout when creating GUILayouts for stages.
+    workflow_editor : WorkflowEditor
+        Workflow editor that contains empty Workflow; re-initialize for custom workflows.
+    xi-help : HelpWidget
+        Interactive helper widget.
     """
+    name = "Ensemble Plugin"
     supports_ensembles = True
 
     def __init__(self, *args, **kwargs):
@@ -37,6 +53,15 @@ class EnsembleGUIPlugin(GUIPlugin):
 
         self.canvases_view.sigInteractiveAction.connect(self.process_action)
 
+        self.workflow_editor = WorkflowEditor(Workflow())
+
+        self.xi_help = HelpWidget()
+
+        self.gui_layout_template = {"center": self.canvases_view,
+                                    "right": self.ensemble_view,
+                                    "rightbottom": self.workflow_editor,
+                                    "leftbottom": self.xi_help}
+
     def _test(self, o):
         print("EnsembleGUIPlugin._test")
 
@@ -46,3 +71,87 @@ class EnsembleGUIPlugin(GUIPlugin):
 
     def appendCatalog(self, catalog: BlueskyRun, **kwargs):
         self.ensemble_model.append_to_ensemble(catalog, None, self._projectors)
+
+
+class HelpWidget(QGroupBox):
+    """Widget that displays interactive help text.
+
+    Installs an event filter on the application that can be used to get and display a widget's `whatsThis` text.
+    """
+    def __init__(self, title="Xi-Help", parent=None):
+        super(HelpWidget, self).__init__(title, parent)
+        self.setObjectName(self.__class__.__name__)
+        self.setWhatsThis("This widget displays any available help text "
+                          "when you hover your mouse over a widget in Xi-CAM."
+                          "Try it out!")
+
+        self._install_event_filter()
+
+        self._help_display = QTextEdit()
+        self._help_display.setContextMenuPolicy(Qt.NoContextMenu)
+        self._help_display.setReadOnly(True)
+        self._help_display.setPlaceholderText("(No help available)")
+
+        layout = QVBoxLayout()
+        layout.addWidget(self._help_display)
+        self.setLayout(layout)
+
+        # Stores a weakref to a previously entered widget
+        self._cached_entered_widget = lambda: None  # type: weakref.ref
+
+    def _install_event_filter(self):
+        """Install self.eventFilter to the application.
+
+        This lets this widget listen to all events,
+        and capture relevant events for updating its internal helper text.
+        """
+        app = QApplication.instance()
+        if app is not None:
+            app.installEventFilter(self)
+
+    # FIXME: better (shorter) name; want to convey this information so it isn't confusing when revisiting.
+    def _is_child_of_previously_entered_widget_with_help_text(self, widget: QWidget) -> bool:
+        """Checks if the cached entered widget is an ancestor of the passed widget.
+
+        Supports maintaining the help text of an entered widget when its children do not have help text.
+        Since we are checking if the cached widget is an ancestor of the widget being left (w/ Leave event),
+        we don't have to manage releasing the cached widget ref (to a duck-typed lambda: None).
+        """
+        entered_widget = self._cached_entered_widget()
+        if entered_widget is not None:
+            return entered_widget.isAncestorOf(widget)
+        return False
+
+
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
+        """Event filter to process an event for the given destination.
+
+        In this case, this widget listens for Enter events on the application level
+        (during this widget's init, this eventFilter is installed on the app instance).
+
+        When the destination object is a QWidget,
+        we can try to update this widget's help_text with the destination widget's what's this help text.
+        If there is no what's this text, we set the help_text back to its placeholderText.
+        """
+        if event.type() == QEvent.Enter:
+            if isinstance(obj, QWidget):
+                help_text = obj.whatsThis()
+                # When the obj has help text, let's update the help text widget
+                if help_text != "":
+                    self._help_display.setText(help_text)
+                    # Store a ref to the entered widget so we can maintain the help text if its children don't have any
+                    self._cached_entered_widget = weakref.ref(obj)
+
+        if event.type() == QEvent.Leave:
+            if isinstance(obj, QWidget):
+                # When we leave a widget, if it didn't have help text,
+                # we want to check if the previously cached (entered) widget is its ancestor.
+                # This will maintain the ancestor's help text in the help text widget when the child has not help text.
+                if obj.whatsThis() == "":
+                    # Revert to placeholder text when we have left a widget and the cached widget is not its ancestor
+                    # (i.e. the previously entered widget with help text is not related).
+                    if not self._is_child_of_previously_entered_widget_with_help_text(obj):
+                        self._help_display.setText(self._help_display.placeholderText())
+
+        return super(HelpWidget, self).eventFilter(obj, event)
+                

--- a/xicam/gui/widgets/linearworkfloweditor.py
+++ b/xicam/gui/widgets/linearworkfloweditor.py
@@ -72,7 +72,7 @@ class WorkflowEditor(QSplitter):
         operation_filter: Callable[[OperationPlugin], bool]
             A callable that can be used to filter which operations to show in the "Add Operation" menu
         kwargs_callable: Callable[[], dict]
-            A callable that gets called when auto-run is triggered. This callable is expected to generate a dict of
+            A callable that gets called when run is triggered. This callable is expected to generate a dict of
             kwargs that will be passed into the workflow as inputs.
         execute_iterative: bool
             Determines if the attached workflow will be executed with `.execute` or `.execute_all`. When `.execute_all`
@@ -112,6 +112,12 @@ class WorkflowEditor(QSplitter):
         self.addWorkflow = self.workflow_widget.addWorkflow
         self.removeWorkflow = self.workflow_widget.removeWorkflow
         self.workflows = self.workflow_widget.workflows
+
+        self.setToolTip("Workflow Editor")
+        self.setWhatsThis("This widget is the Workflow Editor. "
+                          "It is used to create linear workflows from installed operations. "
+                          "Enable or disable an operation by clicking on its check or X. "
+                          "Modify parameters of an operation by clicking on its text. ")
 
     @property
     def workflow(self):
@@ -188,6 +194,10 @@ class WorkflowWidget(QWidget):
         self.addfunctionmenu = QToolButton()
         self.addfunctionmenu.setIcon(QIcon(path("icons/addfunction.png")))
         self.addfunctionmenu.setText("Add Function")
+        self.addfunctionmenu.setToolTip("Add Operation")
+        self.addfunctionmenu.setWhatsThis("This button can be used to add a new operation to the end of a workflow. "
+                                          "A menu to select operations will be populated based on the installed "
+                                          "operations' categories.")
         # Defer menu population to once the plugins have been loaded; otherwise, the menu may not contain anything
         # if this widget is init'd before all plugins have been loaded.
         self.functionmenu = QMenu()
@@ -202,6 +212,10 @@ class WorkflowWidget(QWidget):
         self.workflow_selector = QToolButton()
         self.workflow_selector.setIcon(QIcon(path("icons/bookshelf.png")))
         self.workflow_selector.setText("Select Workflow")
+        self.workflow_selector.setToolTip("Workflow Library")
+        self.workflow_selector.setWhatsThis("This button allows switching between any stored workflows. "
+                                            "(Stored workflows are typically defined programmatically "
+                                            "in a GUI Plugin's modules.)")
         self.workflow_selector.setMenu(self.workflow_menu)
         self.workflow_selector.setPopupMode(QToolButton.InstantPopup)
         self.toolbar.addWidget(self.workflow_selector)
@@ -209,10 +223,15 @@ class WorkflowWidget(QWidget):
         self.toolbar.addWidget(self.addfunctionmenu)
         # self.toolbar.addAction(QIcon(path('icons/up.png')), 'Move Up')
         # self.toolbar.addAction(QIcon(path('icons/down.png')), 'Move Down')
-        self.toolbar.addAction(QIcon(path("icons/save.png")), "Export Workflow")
-        self.toolbar.addAction(QIcon(path("icons/folder.png")), "Import Workflow")
+        action = self.toolbar.addAction(QIcon(path("icons/save.png")), "Export Workflow")
+        action.setEnabled(False)  # FIXME: implement export workflow feature
+        action = self.toolbar.addAction(QIcon(path("icons/folder.png")), "Import Workflow")
+        action.setEnabled(False)  # FIXME: implement import workflow feature
 
-        self.toolbar.addAction(QIcon(path("icons/trash.png")), "Delete Operation", self.deleteOperation)
+        action = self.toolbar.addAction(QIcon(path("icons/trash.png")), "Delete Operation", self.deleteOperation)
+        action.setWhatsThis("This button removes the currently selected operation from the workflow. "\
+                            "(The currently selected operation is highlighted. "\
+                            "An operation is selected when its text is clicked in the workflow editor.")
 
         v = QVBoxLayout()
         v.addWidget(self.view)

--- a/xicam/gui/widgets/views.py
+++ b/xicam/gui/widgets/views.py
@@ -29,6 +29,10 @@ class CanvasView(QAbstractItemView):
 
         self._last_seen_intents = set()
 
+        self.setWhatsThis(
+            "This area will display any items that are checked in the data selector view (the widget on the right)."
+        )
+
     def refresh(self):
         for i in range(self.model().rowCount()):
             self.model().setData(self.model().index(i,0), None, role=EnsembleModel.canvas_role)
@@ -133,6 +137,10 @@ class CanvasDisplayWidget(QWidget):
     def __init__(self, parent=None):
         super(CanvasDisplayWidget, self).__init__(parent)
 
+        self.setWhatsThis(
+            "This area will display any items that are checked in the data selector view (the widget on the right)."
+        )
+
     def clear_canvases(self):
         """Clear all canvases from the widget."""
         ...
@@ -188,6 +196,8 @@ class StackedCanvasView(CanvasView):
                 button = QPushButton(self)
                 button.setCheckable(True)
                 button.setIcon(self.canvas_display_widgets[i].icon)
+                button.setToolTip(getattr(self.canvas_display_widgets[i], "tool_tip", None))
+                button.setWhatsThis(getattr(self.canvas_display_widgets[i], "whats_this", None))
                 # Add the button to the logical button group
                 self.buttongroup.addButton(button, i)
                 # Add the button to the visual layout section
@@ -249,7 +259,13 @@ class CanvasDisplayTabWidget(CanvasDisplayWidget):
         self.layout().setContentsMargins(0, 0, 0, 0)
         self.layout().addWidget(self._tabWidget)
 
+        # Set attrs for when the buttons are created
         self.icon = QIcon(path('icons/tabs.png'))
+        # TODO: right now, we are not attaching help text directly to this widget
+        #   (it can be confusing when trying to hover over the StackedCanvasView,
+        #   the StackedCanvasView's help text is hard to display)
+        self.tool_tip = "Tab View"
+        self.whats_this = "Reorganizes displayed data into separate tabs."
 
     def getView(self):
         return self._tabWidget.currentWidget()
@@ -299,7 +315,10 @@ class SplitHorizontal(SplitView):
 
         self.max_canvases = 2
 
+        # Set attrs for when the buttons are created
         self.icon = QIcon(path('icons/1x1hor.png'))
+        self.tool_tip = "Horizontal Split View"
+        self.whats_this = "Displays up to two visualized data items in a horizontal layout."
 
     def clear_canvases(self):
         for i in reversed(range(self.splitter.count())):
@@ -319,7 +338,11 @@ class SplitVertical(SplitHorizontal):
         super(SplitVertical, self).__init__(*args, **kwargs)
 
         self.splitter.setOrientation(Qt.Horizontal)
+
+        # Set attrs for when the buttons are created
         self.icon = QIcon(path('icons/1x1vert.png'))
+        self.tool_tip = "Vertical Split View"
+        self.whats_this = "Displays up to two visualized data items in a vertical layout."
 
 
 class SplitThreeView(SplitView):
@@ -342,7 +365,10 @@ class SplitThreeView(SplitView):
 
         self.max_canvases = 3
 
+        # Set attrs for when the buttons are created
         self.icon = QIcon(path('icons/2x1grid.png'))
+        self.tool_tip = "3-Way Split View"
+        self.whats_this = "Displays up to three visualized data items."
 
     def clear_canvases(self):
         for splitter in [self.top_splitter, self.outer_splitter]:
@@ -391,7 +417,10 @@ class SplitGridView(SplitView):
 
         self.max_canvases = 4
 
+        # Set attrs for when the buttons are created
         self.icon = QIcon(path('icons/2x2grid.png'))
+        self.tool_tip = "2x2 Grid View"
+        self.whats_this = "Displays up to four visualized data items in a grid layout."
 
     def moveSplitter( self, index, pos):
         splt = self._spltA if self.sender() == self._spltB else self._spltB
@@ -478,6 +507,15 @@ class DataSelectorView(QTreeView):
         self.setDragEnabled(True)
 
         self.setAnimated(True)
+
+        self.setWhatsThis("This widget helps organize and display any loaded data or data created within Xi-CAM. "
+                          "Data is displayed in a tree-like manner:\n"
+                          "  Collection\n"
+                          "    Catalog\n"
+                          "      Visualizable Data\n"
+                          "Click on the items' checkboxes to visualize them.\n"
+                          "Right-click a Collection to rename it.\n"
+                          "Right-click in empty space to create a new Collection.\n")
 
     def setModel(self, model):
         try:


### PR DESCRIPTION
Maintaining documentation can sometimes be difficult. Online documentation can quickly become outdated or disorganized. Finding the documentation can be confusing if you aren't accustomed to readthedocs or github. The documentation itself is functionally separate from Xi-CAM (opens in a browser, need to switch between applications if you have limited monitor space).

I think the documentation we do have is great; adding an interactive widget within Xi-CAM itself to show some form of documentation / help could be incredibly useful. Additionally, using this interactive help widget means defining inline documentation / help text next to the code itself.

This PR adds some documentation (via `QtWidget.whatsThis`) and adds the interactive helper widget (currently added to EnsembleGUIPlugins as the bottomleft widget.

### PR Changes

* `HelpWidget` (Xi-Help) interactive help widget added to `EnsembleGUIPlugin`. When you hover over a widget that has its `whatsThis` text set, Xi-Help displays that text automatically. Handles cases with ancestry and whats this text.
* Add new `gui_layout_template` to `EnsembleGUIPlugin`. Provides dictionary (which map to the `GUILayout` kwargs) for convenience in EnsembleGUIPlugin subclasses when creating `GUILayouts` for stages.
* Add help text to linearworkflowview
* Add hep text to views