### PR TITLE
Add extra safety for running workflows, when kwargs_callable raises

### DIFF
--- a/xicam/gui/models/__init__.py
+++ b/xicam/gui/models/__init__.py
@@ -202,12 +202,23 @@ class EnsembleModel(TreeModel):
             ensemble_item = self.add_ensemble(ensemble, projectors)
 
         # Add catalogs / intents
+        # FIXME: do we need to do this if block if we instead append catalog to the ensemble directly,
+        #    then call self.add_ensemble?
         if ensemble_item is not None:
             end_row = ensemble_item.childCount()
             # Use begin/end to notify views (e.g. dataselectorview) that it needs to update view after item is inserted
             self.beginInsertRows(self.index(ensemble_item.row(), 0), end_row, end_row+1)
             self._create_catalog_item(ensemble_item, catalog, projectors)
             self.endInsertRows()
+
+            # NOTE: this is required to establish the Ensemble to Catalog object relationship
+            #     (CalibrateGUIPlugin.begin_calibrate calls:
+            #         self.ensemble_model.catalogs_from_ensemble(active_ensemble),
+            #         which internally does:
+            #             return ensemble.data(self.object_role).catalogs
+            #      So, if the Ensemble object hasn't had catalogs added to it, we get None back,
+            #      even though there could be a catalog item under an ensemble item.
+            ensemble_item.data(self.object_role).append_catalog(catalog)
 
             # Set check state Checked for newly created catalog item
             #  (this will automatically check all intents in the catalog and refresh the canvas views)

--- a/xicam/gui/widgets/linearworkfloweditor.py
+++ b/xicam/gui/widgets/linearworkfloweditor.py
@@ -139,16 +139,7 @@ class WorkflowEditor(QSplitter):
                 # NOTE: we do not want to raise an exception here (we are in a connected Qt slot)
                 # Grab the user-oriented message from the kwargs callable exception
                 msg.notifyMessage(str(e), title="Run Workflow Error", level=msg.ERROR)
-
-                # Log a more detailed error message that includes the kwargs callable name
-                # and the workflow name
-                kwargs_callable_name = self.kwargs_callable.__name__
-                workflow_name = self.workflow.name
-                detail_text = f'Error occurred when trying to run the kwargs_callable function ' \
-                              f'"{kwargs_callable_name}" ' \
-                              f'in the "{workflow_name}" workflow.'
-                message = f"{detail_text}"
-                msg.logMessage(message, level=msg.ERROR, caller_name=kwargs_callable_name)
+                msg.logError(e)
             else:
                 mixed_kwargs.update(called_kwargs)
                 mixed_kwargs.update(kwargs)


### PR DESCRIPTION
If `LinearWorkflowEditor.run_workflow` has an exception occur in it (e.g. the `kwargs_callable` function raises), we should not continue the workflow and should issue appropriate messages to the user and to the log.

---

Also, including another change:

The `append_to_ensemble` method looks like it does _not_ create a relationship between the `Ensemble` object it creates (if no ensemble_item passed) and the `catalog` passed to it. The Ensemble objects should have a list of its catalog objects. 

This creates a potential issue when `append_to_ensemble` is called in `EnsembleGUIPlugin.appendCatalog`:

```python
self.ensemble_model.append_to_ensemble(catalog, None, self._projectors)
```
and the new Ensemble object created never has its catalog appended to it.

To fix, I just added a `ensemble_item.data(self.object_role).append_catalog(catalog)` to the end of the method after `_create_catalog_item` has been called.

 If `append_catalog` happens when the Ensemble object is first created, then we end up with 2 catalog items (the `add_ensemble` that occurs after the Ensemble object creation will create 1 catalog item for the 1 catalog in `Ensemble.catalogs`; then, the `_create_catalog_item` called later will insert a 2 catalog item in the tree.
