### PR TITLE
fix x (and y) curve labels to show actual data (instead of log values…

### DIFF
--- a/xicam/gui/widgets/plotwidgetmixins.py
+++ b/xicam/gui/widgets/plotwidgetmixins.py
@@ -1,3 +1,4 @@
+import math
 from enum import Enum, auto
 from functools import wraps
 from types import FunctionType
@@ -108,7 +109,11 @@ class CurveLabels(HoverHighlight, ClickHighlight):
         self._arrow = pg.ArrowItem(angle=90)
         self._arrow.setParentItem(self._curvepoint)
         self._arrow.setZValue(10000)
-        self._text = pg.TextItem(f'{item.name()}\nx: {point._data["x"]}\ny: {point._data["y"]}', anchor=(0.5, -.5), border=pg.mkPen("w"), fill=pg.mkBrush("k"))
+        # item.xData[point._index] contains *actual* current point x data value
+        # (as opposed to item.xDisp[point._index] or point._data)
+        x_data = item.xData[point._index]
+        y_data = item.yData[point._index]
+        self._text = pg.TextItem(f'{item.name()}\nx: {x_data}\ny: {y_data}', anchor=(0.5, -.5), border=pg.mkPen("w"), fill=pg.mkBrush("k"))
         self._text.setZValue(10000)
         self._text.setParentItem(self._curvepoint)
 


### PR DESCRIPTION
… in log mode)

Previously the curve label mixin (which shows the x and y values when a point is clicked on a plot curve) was using `point._data`, which is a scatter plot spot item and contains the values according to the axes. If in log mode, the reported values would show the log10 value instead of the actual data value.

Fixed by accessing the plotdataitem's xdata and ydata attributes, and indexing them based on the `point._index`